### PR TITLE
Updated Speedy Labs link

### DIFF
--- a/sdvx/resources/index.md
+++ b/sdvx/resources/index.md
@@ -258,7 +258,7 @@ Virgoo Turbochargers are not supported anymore.
 
 Other:
 
-- **[Speedy Labs](https://www.speedylabs.shop/)**.<br>*[Pocket-SDVX](https://github.com/speedypotato/Pocket-SDVX)* can be bought here.  
+- **[Speedy Labs](https://www.speedylabs.us/)**.<br>*[Pocket-SDVX](https://github.com/speedypotato/Pocket-SDVX)* can be bought here.  
 
 ### Community Guides
 


### PR DESCRIPTION
speedylabs.shop -> speedylabs.us (the new link, as per [SpeedyPotato](https://github.com/speedypotato)'s GitHub profile)
The old domain seems to have expired and was picked up by some ad parking thing.